### PR TITLE
Help to enhance TYPO3 v12 testing / support

### DIFF
--- a/Tests/Functional/Domain/Repository/ColumnRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/ColumnRepositoryTest.php
@@ -20,6 +20,7 @@ final class ColumnRepositoryTest extends FunctionalTestCase
      * @var string[]
      */
     protected array $testExtensionsToLoad = [
+        'typo3conf/ext/jobrouter_base',
         'typo3conf/ext/jobrouter_connector',
         'typo3conf/ext/jobrouter_data',
     ];

--- a/Tests/Functional/Domain/Repository/DatasetRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/DatasetRepositoryTest.php
@@ -20,6 +20,7 @@ final class DatasetRepositoryTest extends FunctionalTestCase
      * @var string[]
      */
     protected array $testExtensionsToLoad = [
+        'typo3conf/ext/jobrouter_base',
         'typo3conf/ext/jobrouter_connector',
         'typo3conf/ext/jobrouter_data',
     ];

--- a/Tests/Functional/Domain/Repository/TableRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/TableRepositoryTest.php
@@ -22,6 +22,7 @@ final class TableRepositoryTest extends FunctionalTestCase
      * @var string[]
      */
     protected array $testExtensionsToLoad = [
+        'typo3conf/ext/jobrouter_base',
         'typo3conf/ext/jobrouter_connector',
         'typo3conf/ext/jobrouter_data',
     ];

--- a/Tests/Functional/Domain/Repository/TransferRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/TransferRepositoryTest.php
@@ -20,6 +20,7 @@ final class TransferRepositoryTest extends FunctionalTestCase
      * @var string[]
      */
     protected array $testExtensionsToLoad = [
+        'typo3conf/ext/jobrouter_base',
         'typo3conf/ext/jobrouter_connector',
         'typo3conf/ext/jobrouter_data',
     ];

--- a/Tests/Functional/Table/TableProviderTest.php
+++ b/Tests/Functional/Table/TableProviderTest.php
@@ -20,6 +20,7 @@ final class TableProviderTest extends FunctionalTestCase
      * @var string[]
      */
     protected array $testExtensionsToLoad = [
+        'typo3conf/ext/jobrouter_base',
         'typo3conf/ext/jobrouter_connector',
         'typo3conf/ext/jobrouter_data',
     ];

--- a/Tests/Functional/Transfer/PreparerTest.php
+++ b/Tests/Functional/Transfer/PreparerTest.php
@@ -23,6 +23,7 @@ final class PreparerTest extends FunctionalTestCase
      * @var string[]
      */
     protected array $testExtensionsToLoad = [
+        'typo3conf/ext/jobrouter_base',
         'typo3conf/ext/jobrouter_connector',
         'typo3conf/ext/jobrouter_data',
     ];

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
 		"phpunit/phpunit": "^9.5.23",
 		"rector/rector": "0.15.3",
 		"saschaegerer/phpstan-typo3": "^1.8",
-		"sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.1.1",
+		"sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.1.2",
 		"symfony/yaml": "^5.4 || ^6.2",
 		"symplify/phpstan-rules": "^11.1.24",
 		"tomasvotruba/cognitive-complexity": "^0.0.5",


### PR DESCRIPTION
### Introduction

This pull-request contains two commits.

**1. adding missing `jobrouter_base` extension in functional test loading**

Functional tests missed to require `jobrouter_base`, which breaks with
TYPO3 v12 package management. By adding this dependency, testing-framework
can properly link all needed dependencies in function test instances.

**2. raising `sbuerk/typo3-cmscomposerinstallers-testingframework-bridge`**

This change raises the testing-framework bridge, which contains the required
bugfix for v12 / composer-installers v5 and testing a extension with dependant
extensions. Without the raise the root extension symlink would clean out prior
linked dependent extensions in legacy paths, thus breaking the require and the
loading in functional test cases.

Fixed issue: https://github.com/sbuerk/typo3-cmscomposerinstallers-testingframework-bridge/issues/7

### Final

However, TYPO3 v12 tests are still red. There are automatic TCA migration deprecations
which let's the tests fail.

Hope it's okay to leave the following v12 tasks to you, and helping with the bugfix
and pull-request is fine for you.

Feel free to merge or cherry pick or change the commits.

Thanks for reporting this issue (never had that on the list).